### PR TITLE
Add content hint

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,7 +42,9 @@ function on_host_load() {
         const canvasElt = document.querySelector("ruffle-player")?.shadowRoot.querySelector("canvas");
         if (canvasElt != null) {
             console.log("Canvas exists, setting up call now");
-            const stream = canvasElt.captureStream(25); // 25 FPS
+            const stream = canvasElt.captureStream(30); // FPS
+            const video_track = stream.getVideoTracks()[0];
+            video_track.contentHint = "motion";
             var call = p.call(guest_video_id, stream);
             console.log("stream=", stream);
             // Disabled, we'll re-enable this for lag-compensation
@@ -89,6 +91,8 @@ function on_guest_load() {
         console.log("received call");
         call.on('stream', function(stream) {
             console.log("On stream, setting video element to ", stream);
+            const video_track = stream.getVideoTracks()[0];
+            video_track.contentHint = "motion";
             document.getElementById("receiving-video").srcObject = stream;
             document.getElementById("receiving-video").play();
         });


### PR DESCRIPTION
Increases frame rate in firefox from avg. 17 to avg. 25 on my machine, providing a better experience.

Before:
![firefox-fps](https://github.com/ZeusWPI/multiplayer-ruffle/assets/40716069/0b6e7341-c6d3-447f-b1c3-9b73719d25b5)

After:
![firefox-yay](https://github.com/ZeusWPI/multiplayer-ruffle/assets/40716069/e2916f4c-a884-47e1-834e-b34954f8b38c)

EDIT: 
On second look, I can't reproduce the behavior which is sensible because firefox does not support content hints (yet).
However, I still think it is good idea to set.
I had no luck with MediaTrackConstraints at all, firefox complains that any constraint on frame rate can't be met (even just `ideal`) and chrome seemingly ignores them.